### PR TITLE
bugfix: SyntaxError: f-string: unmatched '('

### DIFF
--- a/adcheck/core/__main__.py
+++ b/adcheck/core/__main__.py
@@ -745,8 +745,8 @@ class ADcheck:
                         continue
 
                     cert_info = {
-                        'Issuer': ', '.join([f'{key.decode('utf-8')}:{value.decode('utf-8')}' for key, value in cert.get_issuer().get_components()]),
-                        'Subject': ', '.join([f'{key.decode('utf-8')}:{value.decode('utf-8')}' for key, value in cert.get_issuer().get_components()]),
+                        'Issuer': ', '.join([f"{key.decode('utf-8')}:{value.decode('utf-8')}" for key, value in cert.get_issuer().get_components()]),
+                        'Subject': ', '.join([f"{key.decode('utf-8')}:{value.decode('utf-8')}" for key, value in cert.get_issuer().get_components()]),
                         'Version': cert.get_version(),
                         'Not Before': cert.get_notBefore().decode('utf-8'),
                         'Not After': cert.get_notAfter().decode('utf-8'),


### PR DESCRIPTION
fix this error during install due to single quote in singe quotes:

``` 
byte-compiling build/bdist.linux-x86_64/egg/adcheck/modules/__init__.py to __init__.cpython-310.pyc
byte-compiling build/bdist.linux-x86_64/egg/adcheck/modules/RegReader.py to RegReader.cpython-310.pyc
byte-compiling build/bdist.linux-x86_64/egg/adcheck/modules/MSaceCalc.py to MSaceCalc.cpython-310.pyc
byte-compiling build/bdist.linux-x86_64/egg/adcheck/core/__main__.py to __main__.cpython-310.pyc
  File "build/bdist.linux-x86_64/egg/adcheck/core/__main__.py", line 748
    'Issuer': ', '.join([f'{key.decode('utf-8')}:{value.decode('utf-8')}' for key, value in cert.get_issuer().get_components()]),
                                        ^^^
SyntaxError: f-string: unmatched '('

byte-compiling build/bdist.linux-x86_64/egg/adcheck/core/__init__.py to __init__.cpython-310.pyc
```