### PR TITLE
Fix modules import after pipx install

### DIFF
--- a/adcheck/app.py
+++ b/adcheck/app.py
@@ -2,10 +2,9 @@ import sys
 
 sys.path.append('adcheck')
 
-from libs.msldap.commons.factory import LDAPConnectionFactory
-from core.__main__ import ADcheck, Options
-from modules.constants import CHECKLIST
-from modules.report import ReportGenerator
+from adcheck.libs.msldap.commons.factory import LDAPConnectionFactory
+from adcheck.modules.constants import CHECKLIST
+from adcheck.modules.report import ReportGenerator
 from argparse import ArgumentParser
 import asyncio
 

--- a/adcheck/libs/msldap/client.py
+++ b/adcheck/libs/msldap/client.py
@@ -10,19 +10,19 @@ import string
 import random
 from typing import List, Dict, Tuple
 
-from msldap import logger
-from msldap.commons.common import MSLDAPClientStatus
-from msldap.wintypes.asn1.sdflagsrequest import SDFlagsRequest, SDFlagsRequestValue
-from msldap.protocol.constants import BASE, ALL_ATTRIBUTES, LEVEL
+from adcheck.libs.msldap import logger
+from adcheck.libs.msldap.commons.common import MSLDAPClientStatus
+from adcheck.libs.msldap.wintypes.asn1.sdflagsrequest import SDFlagsRequest, SDFlagsRequestValue
+from adcheck.libs.msldap.protocol.constants import BASE, ALL_ATTRIBUTES, LEVEL
 
-from msldap.protocol.query import escape_filter_chars
-from msldap.connection import MSLDAPClientConnection
-from msldap.protocol.messages import Control
-from msldap.ldap_objects import *
-from msldap.commons.utils import KNOWN_SIDS
-from msldap.commons.target import MSLDAPTarget
-from msldap.wintypes.dnsp.strcutures import DNS_RECORD
-from msldap.commons.exceptions import LDAPSearchException
+from adcheck.libs.msldap.protocol.query import escape_filter_chars
+from adcheck.libs.msldap.connection import MSLDAPClientConnection
+from adcheck.libs.msldap.protocol.messages import Control
+from adcheck.libs.msldap.ldap_objects import *
+from adcheck.libs.msldap.commons.utils import KNOWN_SIDS
+from adcheck.libs.msldap.commons.target import MSLDAPTarget
+from adcheck.libs.msldap.wintypes.dnsp.strcutures import DNS_RECORD
+from adcheck.libs.msldap.commons.exceptions import LDAPSearchException
 from asyauth.common.credentials import UniCredential
 
 from winacl.dtyp.security_descriptor import SECURITY_DESCRIPTOR

--- a/adcheck/libs/msldap/commons/adexplorer.py
+++ b/adcheck/libs/msldap/commons/adexplorer.py
@@ -14,12 +14,12 @@ import calendar
 from datetime import datetime
 from typing import Dict, List
 
-from msldap import logger
-from msldap.ldap_objects import MSADSchemaEntry, MSADInfo_ATTRS, MSADInfo, MSADContainer, MSADContainer_ATTRS, \
+from adcheck.libs.msldap import logger
+from adcheck.libs.msldap.ldap_objects import MSADSchemaEntry, MSADInfo_ATTRS, MSADInfo, MSADContainer, MSADContainer_ATTRS, \
     MSADDomainTrust_ATTRS, MSADDomainTrust, MSADOU, MSADOU_ATTRS, MSADUser, MSADUser_ATTRS, MSADGroup, MSADGroup_ATTRS,\
     MSADMachine_ATTRS, MSADMachine, MSADGPO_ATTRS, MSADGPO
 
-from msldap.protocol.typeconversion import MSLDAP_BUILTIN_ATTRIBUTE_TYPES, LDAP_WELL_KNOWN_ATTRS
+from adcheck.libs.msldap.protocol.typeconversion import MSLDAP_BUILTIN_ATTRIBUTE_TYPES, LDAP_WELL_KNOWN_ATTRS
 
 ENCODER_SPEFIFIC_FULCTIONS = [
     'single_bool', 'single_str', 'multi_str'

--- a/adcheck/libs/msldap/commons/exceptions.py
+++ b/adcheck/libs/msldap/commons/exceptions.py
@@ -1,5 +1,5 @@
 
-from msldap.protocol.messages import resultCode
+from adcheck.libs.msldap.protocol.messages import resultCode
 
 
 LDAPResultCodeLookup ={

--- a/adcheck/libs/msldap/commons/factory.py
+++ b/adcheck/libs/msldap/commons/factory.py
@@ -7,9 +7,9 @@
 import enum
 import copy
 
-from msldap.commons.target import MSLDAPTarget
-from msldap.client import MSLDAPClient
-from msldap.connection import MSLDAPClientConnection
+from adcheck.libs.msldap.commons.target import MSLDAPTarget
+from adcheck.libs.msldap.client import MSLDAPClient
+from adcheck.libs.msldap.connection import MSLDAPClientConnection
 from asyauth.common.credentials import UniCredential
 
 class LDAPConnectionFactory:

--- a/adcheck/libs/msldap/connection.py
+++ b/adcheck/libs/msldap/connection.py
@@ -2,22 +2,22 @@ import asyncio
 from typing import List, Dict
 import ssl
 
-from msldap import logger
-from msldap.commons.common import MSLDAPClientStatus
-from .commons.target import MSLDAPTarget
-from msldap.protocol.messages import LDAPMessage, BindRequest, \
+from adcheck.libs.msldap import logger
+from adcheck.libs.msldap.commons.common import MSLDAPClientStatus
+from adcheck.libs.msldap.commons.target import MSLDAPTarget
+from adcheck.libs.msldap.protocol.messages import LDAPMessage, BindRequest, \
 	protocolOp, AuthenticationChoice, SaslCredentials, \
 	SearchRequest, AttributeDescription, Filter, Filters, \
 	Controls, Control, SearchControlValue, AddRequest, \
 	ModifyRequest, DelRequest, ExtendedRequest, ExtendedResponse
 
-from msldap.protocol.utils import calcualte_length
-from msldap.protocol.typeconversion import convert_result, convert_attributes, encode_attributes, encode_changes
-from msldap.protocol.query import escape_filter_chars, query_syntax_converter
-from msldap.commons.authbuilder import get_auth_context
-from msldap.network.packetizer import LDAPPacketizer
+from adcheck.libs.msldap.protocol.utils import calcualte_length
+from adcheck.libs.msldap.protocol.typeconversion import convert_result, convert_attributes, encode_attributes, encode_changes
+from adcheck.libs.msldap.protocol.query import escape_filter_chars, query_syntax_converter
+from adcheck.libs.msldap.commons.authbuilder import get_auth_context
+from adcheck.libs.msldap.network.packetizer import LDAPPacketizer
 from asysocks.unicomm.common.target import UniProto
-from msldap.commons.exceptions import LDAPBindException, LDAPAddException, LDAPModifyException, LDAPDeleteException, LDAPSearchException
+from adcheck.libs.msldap.commons.exceptions import LDAPBindException, LDAPAddException, LDAPModifyException, LDAPDeleteException, LDAPSearchException
 from hashlib import sha256
 from asysocks.unicomm.client import UniClient
 from asyauth.common.constants import asyauthProtocol

--- a/adcheck/libs/msldap/ldap_objects/__init__.py
+++ b/adcheck/libs/msldap/ldap_objects/__init__.py
@@ -4,21 +4,21 @@
 #  Tamas Jos (@skelsec)
 #
 
-from msldap.ldap_objects.adinfo import MSADInfo, MSADInfo_ATTRS
-from msldap.ldap_objects.aduser import MSADUser, MSADUser_ATTRS, MSADUser_TSV_ATTRS
-from msldap.ldap_objects.adcomp import MSADMachine, MSADMachine_ATTRS, MSADMachine_TSV_ATTRS
-from msldap.ldap_objects.adsec  import MSADSecurityInfo, MSADTokenGroup
-from msldap.ldap_objects.common import MSLDAP_UAC
-from msldap.ldap_objects.adgroup import MSADGroup, MSADGroup_ATTRS
-from msldap.ldap_objects.adou import MSADOU, MSADOU_ATTRS
-from msldap.ldap_objects.adgpo import MSADGPO, MSADGPO_ATTRS
-from msldap.ldap_objects.adtrust import MSADDomainTrust, MSADDomainTrust_ATTRS
-from msldap.ldap_objects.adschemaentry import MSADSCHEMAENTRY_ATTRS, MSADSchemaEntry
-from msldap.ldap_objects.adca import MSADCA, MSADCA_ATTRS
-from msldap.ldap_objects.adenrollmentservice import MSADEnrollmentService_ATTRS, MSADEnrollmentService
-from msldap.ldap_objects.adcertificatetemplate import MSADCertificateTemplate, MSADCertificateTemplate_ATTRS
-from msldap.ldap_objects.adgmsa import MSADGMSAUser, MSADGMSAUser_ATTRS
-from msldap.ldap_objects.adcontainer import MSADContainer, MSADContainer_ATTRS
+from adcheck.libs.msldap.ldap_objects.adinfo import MSADInfo, MSADInfo_ATTRS
+from adcheck.libs.msldap.ldap_objects.aduser import MSADUser, MSADUser_ATTRS, MSADUser_TSV_ATTRS
+from adcheck.libs.msldap.ldap_objects.adcomp import MSADMachine, MSADMachine_ATTRS, MSADMachine_TSV_ATTRS
+from adcheck.libs.msldap.ldap_objects.adsec  import MSADSecurityInfo, MSADTokenGroup
+from adcheck.libs.msldap.ldap_objects.common import MSLDAP_UAC
+from adcheck.libs.msldap.ldap_objects.adgroup import MSADGroup, MSADGroup_ATTRS
+from adcheck.libs.msldap.ldap_objects.adou import MSADOU, MSADOU_ATTRS
+from adcheck.libs.msldap.ldap_objects.adgpo import MSADGPO, MSADGPO_ATTRS
+from adcheck.libs.msldap.ldap_objects.adtrust import MSADDomainTrust, MSADDomainTrust_ATTRS
+from adcheck.libs.msldap.ldap_objects.adschemaentry import MSADSCHEMAENTRY_ATTRS, MSADSchemaEntry
+from adcheck.libs.msldap.ldap_objects.adca import MSADCA, MSADCA_ATTRS
+from adcheck.libs.msldap.ldap_objects.adenrollmentservice import MSADEnrollmentService_ATTRS, MSADEnrollmentService
+from adcheck.libs.msldap.ldap_objects.adcertificatetemplate import MSADCertificateTemplate, MSADCertificateTemplate_ATTRS
+from adcheck.libs.msldap.ldap_objects.adgmsa import MSADGMSAUser, MSADGMSAUser_ATTRS
+from adcheck.libs.msldap.ldap_objects.adcontainer import MSADContainer, MSADContainer_ATTRS
 
 
 __all__ = [

--- a/adcheck/libs/msldap/ldap_objects/adcomp.py
+++ b/adcheck/libs/msldap/ldap_objects/adcomp.py
@@ -6,8 +6,8 @@
 
 import datetime
 import base64
-from msldap.ldap_objects.common import MSLDAP_UAC, vn
-from msldap.commons.utils import bh_dt_convert
+from adcheck.libs.msldap.ldap_objects.common import MSLDAP_UAC, vn
+from adcheck.libs.msldap.commons.utils import bh_dt_convert
 
 MSADMachine_ATTRS = [
 	'accountExpires', 'badPasswordTime', 'badPwdCount', 'cn', 'description', 'codePage', 

--- a/adcheck/libs/msldap/ldap_objects/adcontainer.py
+++ b/adcheck/libs/msldap/ldap_objects/adcontainer.py
@@ -4,7 +4,7 @@
 #  Tamas Jos (@skelsec)
 #
 import base64
-from msldap.commons.utils import bh_dt_convert
+from adcheck.libs.msldap.commons.utils import bh_dt_convert
 
 
 

--- a/adcheck/libs/msldap/ldap_objects/adenrollmentservice.py
+++ b/adcheck/libs/msldap/ldap_objects/adenrollmentservice.py
@@ -1,6 +1,6 @@
 
 
-from msldap.commons.utils import print_cert
+from adcheck.libs.msldap.commons.utils import print_cert
 from asn1crypto.x509 import Certificate
 
 MSADEnrollmentService_ATTRS = ['cACertificate', 'msPKI-Enrollment-Servers', 'dNSHostName', 'cn', 'sn', 'distinguishedName', 'whenChanged', 'whenCreated', 'name', 'displayName', 'cACertificateDN', 'certificateTemplates']

--- a/adcheck/libs/msldap/ldap_objects/adgmsa.py
+++ b/adcheck/libs/msldap/ldap_objects/adgmsa.py
@@ -5,7 +5,7 @@
 #
 
 import datetime #, timedelta, timezone
-from msldap.ldap_objects.common import MSLDAP_UAC, vn
+from adcheck.libs.msldap.ldap_objects.common import MSLDAP_UAC, vn
 
 MSADGMSAUser_ATTRS = [ 	
 	'accountExpires', 'badPasswordTime', 'badPwdCount', 'cn', 'codePage', 

--- a/adcheck/libs/msldap/ldap_objects/adgpo.py
+++ b/adcheck/libs/msldap/ldap_objects/adgpo.py
@@ -4,8 +4,8 @@
 #  Tamas Jos (@skelsec)
 #
 
-from msldap.ldap_objects.common import MSLDAP_UAC, vn
-from msldap.commons.utils import bh_dt_convert
+from adcheck.libs.msldap.ldap_objects.common import MSLDAP_UAC, vn
+from adcheck.libs.msldap.commons.utils import bh_dt_convert
 
 
 MSADGPO_ATTRS = [

--- a/adcheck/libs/msldap/ldap_objects/adgroup.py
+++ b/adcheck/libs/msldap/ldap_objects/adgroup.py
@@ -4,10 +4,10 @@
 #  Tamas Jos (@skelsec)
 #
 
-from msldap.wintypes import *
-from msldap.ldap_objects.common import MSLDAP_UAC, vn
+from adcheck.libs.msldap.wintypes import *
+from adcheck.libs.msldap.ldap_objects.common import MSLDAP_UAC, vn
 from winacl.dtyp.sid import SID
-from msldap.commons.utils import bh_dt_convert
+from adcheck.libs.msldap.commons.utils import bh_dt_convert
 
 
 MSADGroup_ATTRS = [ 	

--- a/adcheck/libs/msldap/ldap_objects/adinfo.py
+++ b/adcheck/libs/msldap/ldap_objects/adinfo.py
@@ -4,8 +4,8 @@
 #  Tamas Jos (@skelsec)
 #
 
-from msldap.commons.utils import bh_dt_convert
-from msldap.commons.utils import FUNCTIONAL_LEVELS
+from adcheck.libs.msldap.commons.utils import bh_dt_convert
+from adcheck.libs.msldap.commons.utils import FUNCTIONAL_LEVELS
 
 MSADInfo_ATTRS = [
 	'auditingPolicy', 'creationTime', 'dc', 'distinguishedName', 

--- a/adcheck/libs/msldap/ldap_objects/adou.py
+++ b/adcheck/libs/msldap/ldap_objects/adou.py
@@ -4,7 +4,7 @@
 #  Tamas Jos (@skelsec)
 #
 import base64
-from msldap.commons.utils import bh_dt_convert
+from adcheck.libs.msldap.commons.utils import bh_dt_convert
 
 
 

--- a/adcheck/libs/msldap/ldap_objects/adsec.py
+++ b/adcheck/libs/msldap/ldap_objects/adsec.py
@@ -6,7 +6,7 @@
 
 
 from winacl.dtyp.sid import SID
-from msldap.ldap_objects.common import MSLDAP_UAC, vn
+from adcheck.libs.msldap.ldap_objects.common import MSLDAP_UAC, vn
 
 class MSADTokenGroup:
 	def __init__(self):

--- a/adcheck/libs/msldap/ldap_objects/adtrust.py
+++ b/adcheck/libs/msldap/ldap_objects/adtrust.py
@@ -7,7 +7,7 @@
 import enum
 
 from winacl.dtyp.sid import SID
-from msldap.ldap_objects.common import MSLDAP_UAC, vn
+from adcheck.libs.msldap.ldap_objects.common import MSLDAP_UAC, vn
 
 MSADDomainTrust_ATTRS = [ 
 	'sn', 

--- a/adcheck/libs/msldap/ldap_objects/aduser.py
+++ b/adcheck/libs/msldap/ldap_objects/aduser.py
@@ -5,8 +5,8 @@
 #
 
 import datetime #, timedelta, timezone
-from msldap.ldap_objects.common import MSLDAP_UAC, vn
-from msldap.commons.utils import bh_dt_convert
+from adcheck.libs.msldap.ldap_objects.common import MSLDAP_UAC, vn
+from adcheck.libs.msldap.commons.utils import bh_dt_convert
 
 MSADUser_ATTRS = [ 	
 	'accountExpires', 'badPasswordTime', 'badPwdCount', 'cn', 'codePage', 

--- a/adcheck/libs/msldap/network/packetizer.py
+++ b/adcheck/libs/msldap/network/packetizer.py
@@ -1,7 +1,7 @@
 import asyncio
 
-from msldap import logger
-from msldap.protocol.utils import calcualte_length
+from adcheck.libs.msldap import logger
+from adcheck.libs.msldap.protocol.utils import calcualte_length
 from asysocks.unicomm.common.packetizers import Packetizer
 
 class LDAPPacketizer(Packetizer):

--- a/adcheck/libs/msldap/protocol/ldap_filter/filter.py
+++ b/adcheck/libs/msldap/protocol/ldap_filter/filter.py
@@ -1,8 +1,8 @@
 import re
 import platform
 
-from msldap.protocol.ldap_filter import parser
-from msldap.protocol.ldap_filter.soundex import soundex_compare
+from adcheck.libs.msldap.protocol.ldap_filter import parser
+from adcheck.libs.msldap.protocol.ldap_filter.soundex import soundex_compare
 
 
 class LDAPBase:

--- a/adcheck/libs/msldap/protocol/query.py
+++ b/adcheck/libs/msldap/protocol/query.py
@@ -1,7 +1,7 @@
 from .ldap_filter import Filter as LF
 from .ldap_filter.filter import LDAPBase
 from asn1crypto.core import ObjectIdentifier
-from msldap.protocol.messages import Filter, Filters, \
+from adcheck.libs.msldap.protocol.messages import Filter, Filters, \
 	AttributeDescription, SubstringFilter, MatchingRuleAssertion, \
 	Substrings, Substring
 

--- a/adcheck/libs/msldap/protocol/typeconversion.py
+++ b/adcheck/libs/msldap/protocol/typeconversion.py
@@ -4,9 +4,9 @@ import re
 from winacl.dtyp.sid import SID
 from winacl.dtyp.guid import GUID
 from winacl.dtyp.security_descriptor import SECURITY_DESCRIPTOR
-from msldap import logger
-from msldap.protocol.messages import Attribute, Change, PartialAttribute
-from msldap.wintypes.managedpassword import MSDS_MANAGEDPASSWORD_BLOB
+from adcheck.libs.msldap import logger
+from adcheck.libs.msldap.protocol.messages import Attribute, Change, PartialAttribute
+from adcheck.libs.msldap.wintypes.managedpassword import MSDS_MANAGEDPASSWORD_BLOB
 
 MSLDAP_DT_WIN_EPOCH = datetime.datetime(1601, 1, 1)
 

--- a/adcheck/libs/msldap/relay/server.py
+++ b/adcheck/libs/msldap/relay/server.py
@@ -1,7 +1,7 @@
 from asysocks.unicomm.common.target import UniTarget, UniProto
 from asysocks.unicomm.server import UniServer
-from msldap.network.packetizer import LDAPPacketizer
-from msldap.relay.serverconnection import LDAPRelayServerConnection
+from adcheck.libs.msldap.network.packetizer import LDAPPacketizer
+from adcheck.libs.msldap.relay.serverconnection import LDAPRelayServerConnection
 from asyauth.protocols.spnego.relay.native import spnegorelay_ntlm_factory
 from asyauth.protocols.ntlm.relay.native import NTLMRelaySettings, ntlmrelay_factory
 import traceback

--- a/adcheck/libs/msldap/relay/serverconnection.py
+++ b/adcheck/libs/msldap/relay/serverconnection.py
@@ -1,6 +1,6 @@
-from msldap.protocol.utils import calcualte_length
-from msldap.protocol.messages import LDAPMessage, AuthenticationChoice, protocolOp, BindResponse
-from msldap import logger
+from adcheck.libs.msldap.protocol.utils import calcualte_length
+from adcheck.libs.msldap.protocol.messages import LDAPMessage, AuthenticationChoice, protocolOp, BindResponse
+from adcheck.libs.msldap import logger
 import traceback
 import asyncio
 

--- a/adcheck/modules/ADmanage.py
+++ b/adcheck/modules/ADmanage.py
@@ -1,5 +1,5 @@
-from libs.msldap.commons.factory import LDAPConnectionFactory
-from libs.impacket.structure import Structure
+from adcheck.libs.msldap.commons.factory import LDAPConnectionFactory
+from adcheck.libs.impacket.structure import Structure
 import socket
 import dns.resolver
 

--- a/adcheck/modules/MSaceCalc.py
+++ b/adcheck/modules/MSaceCalc.py
@@ -1,4 +1,4 @@
-from libs.impacket.ldap.ldaptypes import SR_SECURITY_DESCRIPTOR
+from adcheck.libs.impacket.ldap.ldaptypes import SR_SECURITY_DESCRIPTOR
 from modules.constants import ENTRANCE_ACCESS_CONTROL, REGISTRY_ACCESS_RIGHT, LAPS_PROPERTIES_UUID, REGISTRY_ACCESS_INHERITED, DELEGATIONS_ACE
 import uuid
 

--- a/adcheck/modules/RegReader.py
+++ b/adcheck/modules/RegReader.py
@@ -1,6 +1,6 @@
-from libs.impacket.dcerpc.v5 import transport, rrp, scmr
-from libs.impacket.smbconnection import SMBConnection
-from libs.impacket.system_errors import ERROR_NO_MORE_ITEMS
+from adcheck.libs.impacket.dcerpc.v5 import transport, rrp, scmr
+from adcheck.libs.impacket.smbconnection import SMBConnection
+from adcheck.libs.impacket.system_errors import ERROR_NO_MORE_ITEMS
 from struct import unpack
 import binascii
 

--- a/adcheck/modules/SmallSecretsDump.py
+++ b/adcheck/modules/SmallSecretsDump.py
@@ -1,5 +1,5 @@
-from libs.impacket.smbconnection import SMBConnection
-from libs.impacket.examples.secretsdump import RemoteOperations, NTDSHashes
+from adcheck.libs.impacket.smbconnection import SMBConnection
+from adcheck.libs.impacket.examples.secretsdump import RemoteOperations, NTDSHashes
 
 
 class DumpSecrets:

--- a/adcheck/modules/report.py
+++ b/adcheck/modules/report.py
@@ -1,4 +1,4 @@
-from modules.constants import CHECKLIST
+from adcheck.modules.constants import CHECKLIST
 from jinja2 import Environment, FileSystemLoader
 from os import path
 import plotly.graph_objects as go


### PR DESCRIPTION
Hello! 

I had issues installing ADCheck using pipx. The import of modules was not working, probably because msldap is not installed on my machines. I've made these changes to use the modules in the libs folder, and it worked for me. 

![image](https://github.com/user-attachments/assets/ab3f6d4a-b857-4fad-8659-1c131d81d7de)

Thanks!